### PR TITLE
Feat: display btnClear and btnDel

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -25,4 +25,14 @@ btnDiv.addEventListener("click", (e) => {
   outputDisplay.textContent += "/";
 });
 
+btnDel.addEventListener("click", (e) => {
+  e.preventDefault();
+  del();
+});
 
+const del = () => {
+  const currentContent = outputDisplay.textContent;
+  if (currentContent.length > 0) {
+    outputDisplay.textContent = currentContent.slice(0, -1);
+  }
+};

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -3,23 +3,26 @@ const btnSum = document.getElementById("btn-sum");
 const btnMin = document.getElementById("btn-min");
 const btnMultiply = document.getElementById("btn-multiply");
 const btnDiv = document.getElementById("btn-div");
+const btnDel = document.getElementById("btn-del");
 
 btnSum.addEventListener("click", (e) => {
   e.preventDefault();
-  outputDisplay.textContent = "+";
+  outputDisplay.textContent += "+";
 });
 
 btnMin.addEventListener("click", (e) => {
   e.preventDefault();
-  outputDisplay.textContent = "-";
+  outputDisplay.textContent += "-";
 });
 
 btnMultiply.addEventListener("click", (e) => {
   e.preventDefault();
-  outputDisplay.textContent = "*";
+  outputDisplay.textContent += "*";
 });
 
 btnDiv.addEventListener("click", (e) => {
   e.preventDefault();
-  outputDisplay.textContent = "/";
+  outputDisplay.textContent += "/";
 });
+
+

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -4,6 +4,7 @@ const btnMin = document.getElementById("btn-min");
 const btnMultiply = document.getElementById("btn-multiply");
 const btnDiv = document.getElementById("btn-div");
 const btnDel = document.getElementById("btn-del");
+const btnClear = document.getElementById("btn-clear");
 
 btnSum.addEventListener("click", (e) => {
   e.preventDefault();
@@ -30,9 +31,18 @@ btnDel.addEventListener("click", (e) => {
   del();
 });
 
+btnClear.addEventListener("click", (e) => {
+  e.preventDefault();
+  clear();
+});
+
 const del = () => {
   const currentContent = outputDisplay.textContent;
   if (currentContent.length > 0) {
     outputDisplay.textContent = currentContent.slice(0, -1);
   }
+};
+
+const clear = () => {
+  outputDisplay.textContent = "";
 };


### PR DESCRIPTION
**Purpose**
The goal of this task is to implement btnClear and btnDel so the user can delete or clear numbers and operators.

**Aproaches and changes**
- btnClear and btnDel have eventListeners to prevent default.
- btnDel has a function called "del()" using slice method to delete each items.
- btnClear has a function called "clear()" reatributing outputDisplay to a empty string("") to delete the whole content.

