### PR TITLE
refactor: correct division by zero

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -61,7 +61,6 @@ btnClear.addEventListener("click", (e) => {
 btnEquals.addEventListener("click", (e) => {
   e.preventDefault();
   calc();
-  console.log(previousOperand);
 });
 
 const del = () => {
@@ -114,17 +113,13 @@ const calc = () => {
       break;
     case "/":
       if (numB === "0") {
-        outputDisplay.textContent +=
-          "Cálculo inválido. Impossível divisão por zero";
-        break;
+        outputDisplay.textContent = "Impossível divisão por zero";
+        return;
       } else {
         result = divide(numA, numB);
-        outputDisplay.textContent = result;
-        break;
       }
+      break;
   }
-
-  result = eval(previousOperand);
 
   outputDisplay.textContent = result;
   previousOperand = outputDisplay.textContent;


### PR DESCRIPTION
**Purpose**
To prevent that the user divides a number by 0, is important to stop the division and throw an Error message.

**Aproaches and changes**
- It was changed the logic in the switch case division so the outputDisplay could return in the textContent the message "Impossível divisão por zero"
- The else statement was also changed so the division by other numbers could happen normally.
- The eval function was removed.